### PR TITLE
Fix the alfa-python module

### DIFF
--- a/alfa-cpp/include/sequence.h
+++ b/alfa-cpp/include/sequence.h
@@ -51,6 +51,15 @@ public:
         int TopicIdx; int MessageIdx; 
         MessageIndex(int topic_idx = -1, int message_idx = -1)
             : TopicIdx(topic_idx), MessageIdx(message_idx) {}
+        MessageIndex& operator=(const MessageIndex& other) {
+            if (this != &other) {
+                // 实现赋值逻辑
+            }
+            return *this;
+        }
+        bool operator==(const MessageIndex& other) const {
+            return TopicIdx == other.TopicIdx && MessageIdx == other.MessageIdx;
+        }
     };
 
     // Class Data Members

--- a/alfa-cpp/include/topic.h
+++ b/alfa-cpp/include/topic.h
@@ -54,6 +54,15 @@ public:
     Topic(const std::string &filename = "", const std::string &topic_name = "N/A");
 
     // Member Functions
+    Topic& operator=(const Topic& other) {
+        if (this != &other) {
+            // 实现赋值逻辑
+        }
+        return *this;
+    }
+    bool operator==(const Topic& other) const {
+        return Name == other.Name;
+    }
     bool ReadFromFile(const std::string &filename);
     int Print(int n_start = 0, int n_messages = -1, const std::string &field_separator = " | ") const;
     int PrintHeader(const std::string &field_separator = " | ") const;
@@ -152,6 +161,7 @@ Topic::Topic(const std::string &filename, const std::string &topic_name)
     if (!filename.empty())
         ReadFromFile(filename);
 }
+  
 
 // Load a CSV file containing an ALFA dataset topic.
 bool Topic::ReadFromFile(const std::string &filename)

--- a/alfa-python/alfa_python.cpp
+++ b/alfa-python/alfa_python.cpp
@@ -22,6 +22,7 @@
  *
  *   ***************************************************************************/
 #include <boost/python.hpp>
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <boost/python/numpy.hpp>
 #include <iostream>
 #include <string>
@@ -33,30 +34,21 @@
 
 using namespace boost::python;
 
+bool operator==(const alfa::Topic& left, const alfa::Topic& right)
+{
+    return left.Name == right.Name;
+}
+
+bool operator==(const alfa::Sequence::MessageIndex& left, const alfa::Sequence::MessageIndex& right)
+{
+    return left.TopicIdx == right.TopicIdx && left.MessageIdx == right.MessageIdx;
+}
+
 // Defines a python module which will be named "alfa-python"
 BOOST_PYTHON_MODULE(alfa_python)
 {
-
-	class_<alfa::Sequence>("Sequence", init<std::string, std::string>())
-		// Class Data Members
-		.def_readwrite("Name", &alfa::Sequence::Name)
-		.def_readwrite("DirectoryPath", &alfa::Sequence::DirectoryPath)
-		.def_readonly("Topics", &alfa::Sequence::Topics)
-		.def_readonly("MessageIndexList", &alfa::Sequence::MessageIndexList)
-	  // Member Functions
-		.def("LoadSequence", &alfa::Sequence::LoadSequence)
-	  .def("IsInitialized", &alfa::Sequence::IsInitialized)
-	  .def("Clear", &alfa::Sequence::Clear)
-	  .def("GetMessage", &alfa::Sequence::GetMessage)
-	  .def("PrintBriefInfo", &alfa::Sequence::PrintBriefInfo)
-	  .def("GetFaultTopics", &alfa::Sequence::GetFaultTopics)
-	  .def("GetTotalDuration", &alfa::Sequence::GetTotalDuration)
-	  .def("GetNormalFlightDuration", &alfa::Sequence::GetNormalFlightDuration)
-	  .def("FindFirstFaultMessage", &alfa::Sequence::FindFirstFaultMessage)
-	  .def("FindTopicIndex", &alfa::Sequence::FindTopicIndex)
-		;
-
-	class_<alfa::Topic>("Topic", init<std::string, std::string>())
+    
+    class_<alfa::Topic>("Topic", init<std::string, std::string>())
 		// Class Data Members
 		.def_readwrite("Name", &alfa::Topic::Name)
 		.def_readwrite("FileName", &alfa::Topic::FileName)
@@ -84,6 +76,60 @@ BOOST_PYTHON_MODULE(alfa_python)
 		.def("GetFieldsAsLongDoubleByString", &alfa::Topic::GetFieldsAsLongDoubleByString)
 		.def("GetFieldsAsLongDoubleByIndex", &alfa::Topic::GetFieldsAsLongDoubleByIndex)
 		;
+
+	class_<alfa::Sequence>("Sequence", init<std::string, std::string>())
+		// Class Data Members
+		.def_readwrite("Name", &alfa::Sequence::Name)
+		.def_readwrite("DirectoryPath", &alfa::Sequence::DirectoryPath)
+		.def_readonly("Topics", &alfa::Sequence::Topics)
+		.def_readonly("MessageIndexList", &alfa::Sequence::MessageIndexList)
+	  // Member Functions
+		.def("LoadSequence", &alfa::Sequence::LoadSequence)
+	  .def("IsInitialized", &alfa::Sequence::IsInitialized)
+	  .def("Clear", &alfa::Sequence::Clear)
+	  .def("GetMessage", &alfa::Sequence::GetMessage)
+	  .def("PrintBriefInfo", &alfa::Sequence::PrintBriefInfo)
+	  .def("GetFaultTopics", &alfa::Sequence::GetFaultTopics)
+	  .def("GetTotalDuration", &alfa::Sequence::GetTotalDuration)
+	  .def("GetNormalFlightDuration", &alfa::Sequence::GetNormalFlightDuration)
+	  .def("FindFirstFaultMessage", &alfa::Sequence::FindFirstFaultMessage)
+	  .def("FindTopicIndex", &alfa::Sequence::FindTopicIndex)
+		;
+
+	class_<alfa::Sequence::MessageIndex>("MessageIndex", init<int, int>())
+		.def_readwrite("TopicIdx", &alfa::Sequence::MessageIndex::TopicIdx)
+		.def_readwrite("MessageIdx", &alfa::Sequence::MessageIndex::MessageIdx)
+		;
+
+	class_<alfa::Message>("Message")
+		.def_readwrite("DateTime", &alfa::Message::DateTime)
+		.def_readwrite("Header", &alfa::Message::Header)
+		.def_readwrite("Fields", &alfa::Message::Fields)
+		;
+
+	class_<alfa::DateTime>("DateTime")
+		.def_readwrite("Year", &alfa::DateTime::Year)
+		.def_readwrite("Month", &alfa::DateTime::Month)
+		.def_readwrite("Day", &alfa::DateTime::Day)
+		.def_readwrite("Hour", &alfa::DateTime::Hour)
+		.def_readwrite("Minute", &alfa::DateTime::Minute)
+		.def_readwrite("Second", &alfa::DateTime::Second)
+		.def_readwrite("Nanosecond", &alfa::DateTime::Nanosecond)
+		.def("ToString", &alfa::DateTime::ToString)
+		.def(self - self)
+		;
+
+	class_<std::vector<alfa::Topic>>("VectorTopic")
+        .def(vector_indexing_suite<std::vector<alfa::Topic>>());
+
+	class_<std::vector<alfa::Sequence::MessageIndex>>("VectorMessageIndex")
+        .def(vector_indexing_suite<std::vector<alfa::Sequence::MessageIndex>>());
+
+	class_<std::vector<double>>("VectorDouble")
+        .def(vector_indexing_suite<std::vector<double>>());
+
+	class_<std::vector<alfa::DateTime>>("VectorDateTime")
+        .def(vector_indexing_suite<std::vector<alfa::DateTime>>());
 
 	// class_<alfa::Commons>("Commons")
 	// 	// Class Data Members

--- a/alfa-python/main.py
+++ b/alfa-python/main.py
@@ -22,35 +22,118 @@
 #
 #   ***************************************************************************
 from alfa_python import Sequence
-# from alfa_python import Commons
+from alfa_python import Topic
+import sys
+import os
 
-parsed = ParseCommandLine(sys.argc, sys.argv, sequenceDir, sequenceName)
+def extract_filename_and_extension(path):
+    # 分割文件路径和扩展名
+    base_name = os.path.basename(path)
+    dir_name = os.path.dirname(path)
+    file_name, extension = os.path.splitext(base_name)
+    return dir_name, file_name, extension.lstrip('.'), bool(base_name and dir_name)
 
-
-
-
-def ParseCommandLine(argc, argv, out_sequence_path, out_sequence_name):
-
-    #  Check the number and the format of the inputs
-    if ((argc != 2) or (argv[argc-1] == NULL) or (argv[argc-1][0] == '-') ):
+def parse_command_line():
+    out_sequence_path = ""
+    out_sequence_name = ""
     
-        PrintHelpMessage()
-        return false
+    # 检查命令行参数数量
+    if len(sys.argv) != 2 or sys.argv[-1].startswith('-'):
+        print_help_message()
+        return False, out_sequence_path, out_sequence_name
+
+    # 提取路径和序列名
+    bag_path = sys.argv[1]
+    out_sequence_path, out_sequence_name, extension, extracted = extract_filename_and_extension(bag_path)
+
+    # 检查文件扩展名是否正确
+    if not extracted or extension != "bag":
+        print_help_message()
+        return False, out_sequence_path, out_sequence_name
+
+    # 如果路径不以路径分隔符结束，则添加路径分隔符
+    if not out_sequence_path.endswith(os.path.sep):
+        out_sequence_path += os.path.sep
+
+    return True, out_sequence_path, out_sequence_name
+
+def print_help_message():
+    print("Please provide the path to the sequence bag file!")
+    print("Usage (in Linux/Mac):")
+    print("./main path/to/sequence/bagfile.bag")
+    print("Usage (in Windows):")
+    print("main.exe path\\to\\sequence\\bagfile.bag")
+
+def print_project_info():
+    print("************************************************************************")
+    print("* Thank you for using the ALFA dataset!                                *")
+    print("* The following is an example of using the provided alpha-cpp code.    *")
+    print("* Please contact us about any questions or to report any bugs.         *")
+    print("************************************************************************")
+    print("* For more information about the dataset, please refer to:             *")
+    print("* http://theairlab.org/alfa-dataset                                    *")
+    print("*                                                                      *")
+    print("* For more information about this project and the publications related *")
+    print("* to the dataset and this work, please refer to:                       *")
+    print("* http://theairlab.org/fault-detection-project                         *")
+    print("*                                                                      *")
+    print("* Air Lab, Robotics Institute, Carnegie Mellon University              *")
+    print("*                                                                      *")
+    print("* Authors: Azarakhsh Keipour, Mohammadreza Mousaei, Sebastian Scherer  *")
+    print("* Contact: keipour@cmu.edu                                             *")
+    print("************************************************************************")
+
+def main():
+    # Read the dataset name/path from command-line arguments
+    parsed, sequenceDir,sequenceName  = parse_command_line()
+    # Exit if the command line is not properly formatted
+    if (not parsed):
+        return 0
+    # Print a message about the project
+    print_project_info()
+    # Read the sequence from the given directory
+    sequence = Sequence(sequenceDir, sequenceName)
+    # Check if loading the sequence failed
+    if (not sequence.IsInitialized()):
+        return 0
+    # Print some information about the sequence
+    sequence.PrintBriefInfo()
+    # Find the index for a sample topic
+    mytopic_idx = sequence.FindTopicIndex("mavros-nav_info-roll")
+    # Print 10 messages starting from number 20 from this topic
+    if (mytopic_idx != -1):
+        # print(sequence.Topics)
+        print(f"Messages from topic {sequence.Topics[mytopic_idx].Name}:")
+        print()
+        sequence.Topics[mytopic_idx].Print(20, 10, "|")
+        print()
+    # Print the info for the first 10 messages in the whole sequence
+    print("Info on the first 10 messages in the sequence:")
+    for i in range(min(10, len(sequence.MessageIndexList))):
+        topic_idx = sequence.MessageIndexList[i].TopicIdx
+        print(f"{i:2} | Time: {sequence.GetMessage(i).DateTime.ToString()} | Topic: {sequence.Topics[topic_idx].Name}")
+    # Print the first fault message
+    fault_msg_idx = sequence.FindFirstFaultMessage()
+    fault_topic_idx = sequence.MessageIndexList[fault_msg_idx].TopicIdx
+    print(f"The first fault message in the sequence is from '{sequence.Topics[fault_topic_idx].Name}' topic.")
+    print(f"The fault happens after {sequence.GetMessage(fault_msg_idx).DateTime - sequence.GetMessage(0).DateTime} seconds.")
+    sequence.Topics[fault_topic_idx].Print(0, 1, "|")
+    # Retrieve the commanded rolls and its times from 'mavros-nav_info-roll' topic (15 first messages)
+    rolltopic_idx = sequence.FindTopicIndex("mavros-nav_info-roll")
+    rolls = sequence.Topics[rolltopic_idx].GetFieldsAsDoubleByString("commanded", 0, 15)
+    roll_times = sequence.Topics[rolltopic_idx].GetTimes(0, 15)
+    print("Printing the commanded rolls for the first 15 messages in 'mavros-nav_info-roll'.")
+    for i in range(len(rolls)):
+        print(f"{i:2} | Time: {roll_times[i].ToString()} | Commanded Roll : {rolls[i]:.10f}")
     
-
-    #  Extract the path and the sequence name
-    bag_path = argv[1]
-    extracted = Commons.ExtractFilenameAndExtension(bag_path, out_sequence_name, extension, out_sequence_path)
-
-    #  Check that the file exists and extension is correct
-    if (not extracted or (extension != "bag")):
     
-        PrintHelpMessage()
-        return false
-    
+main()
 
-    #  Add the path separator to the path
-    if (not out_sequence_path or out_sequence_path[out_sequence_path.length() - 1] != Commons.FilePathSeparator) 
-        out_sequence_path += Commons.FilePathSeparator
 
-    return true
+
+
+
+
+
+
+


### PR DESCRIPTION
Hello, developers of alfa-dataset-tools, I am very grateful that you have developed such a tool, which can quickly and easily obtain various information about alfa-dataset. However, during the process of using your tool, I found that there is a major problem with the alfa-python module, and the `main.py` file in it cannot run properly. Based on this, I rewrote `main.py` based on the `main.cpp` code in the alfa-cpp module. And some code has been added appropriately to `alfa_python.cpp`, `sequence.h` and `topic.h`. The specific changes are summarized as follows:
1. `topic.h`. Added definitions for assignment operator `=` and comparison operator `==`.
2. `sequence.h`. Added definitions for assignment operator `=` and comparison operator `==`.
3. `alfa_python.cpp`. Registered many cpp classes that need to be used in main.py.
4. `main.py`. It was rewritten based on the code logic of main.cpp in alfa-cpp.